### PR TITLE
Integrate Spell Check into CI/CD Pipeline

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,26 @@
+name: Spell Check
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - '**.html'
+      - 'hunspell/**'
+      - 'scripts/run_spell_check.sh'
+      - '.github/workflows/spell-check.yml'
+
+jobs:
+  check-spelling:
+    name: Check spelling (Markdown & HTML)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        
+      - name: Install required packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y hunspell hunspell-en-gb
+          
+      - name: Run spelling check
+        run: ./scripts/run_spell_check.sh


### PR DESCRIPTION
This PR integrates the previously implemented spell check logic into the GitHub Actions CI/CD pipeline.

**Changes included:**
- Added a new `.github/workflows/spell-check.yml` workflow.
- Configured the workflow to run only on `pull_request` events to avoid unnecessary executions on the `main` branch.
- Restricted the execution using `paths` filters so it only runs when relevant files (`.md`, `.html`, `hunspell/**`, `scripts/run_spell_check.sh`, or the workflow itself) are modified.
- Added steps to checkout the repo and `apt-get install hunspell hunspell-en-gb` before running the `./scripts/run_spell_check.sh` script.

Resolved: #14