### PR TITLE
Add Iubenda script after <head>

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -1,1 +1,0 @@
-{%- include iubenda.html -%}

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,4 +1,3 @@
-{% if site.google_analytics and jekyll.environment == 'production' %}
 <!-- Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
 <script>
@@ -9,4 +8,3 @@
     'anonymize_ip': true
   });
 </script>
-{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,17 @@
+<head>
+  {%- if jekyll.environment == 'production' -%}
+    {%- include iubenda.html -%}
+  {%- endif -%}
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+  <link id="main-stylesheet" rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+  {%- feed_meta -%}
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+    {%- include google-analytics.html -%}
+  {%- endif -%}
+
+  {%- include custom-head.html -%}
+  
+</head>

--- a/_includes/iubenda.html
+++ b/_includes/iubenda.html
@@ -1,4 +1,2 @@
-{% if jekyll.environment == 'production' %}
 <!-- Iubenda -->
 <script type="text/javascript" src="https://embeds.iubenda.com/widgets/4c541ab4-9790-4e7a-b01d-499fd1e81b4b.js"></script>
-{% endif %}


### PR DESCRIPTION
This change fixes an issue with the cookie banner that was loaded each time the user navigated to a different page.

Iubenda script must be declared just after the opening of the <head> tag.