### PR TITLE
Add curriculum-vitae submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "curriculum-vitae"]
+	path = curriculum-vitae
+	url = https://github.com/gilbertotcc/curriculum-vitae
+	branch = main

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -88,6 +88,12 @@ specific files. Always refer to these before proceeding with related tasks:
 - **LLM Context:** `llms.txt` provides a machine-readable summary of the site
   for LLMs, including site metadata, page links, and social information. It is
   dynamically generated using Jekyll.
+- **AI Context Submodule:** A private submodule `curriculum-vitae` is used to
+  provide personal data as context for LLM-assisted development.
+  - **Syncing:** The submodule tracks the `main` branch. Use
+    `git submodule update --remote curriculum-vitae` to sync.
+  - **Privacy:** This directory is explicitly excluded in `_config.yml` to
+    ensure it is never processed by Jekyll or published to the website.
 
 ### Theme Customisation
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ The configuration is stored in `.gemini/settings.json` and includes:
 - **GitHub Copilot**: Enables interaction with GitHub for pull requests, issues,
   and repository management.
 
+### Curriculum Vitae Context
+
+The project includes a private submodule `curriculum-vitae` to provide personal
+data for AI-assisted workflows. This directory is excluded from the Jekyll build
+process.
+
+To update the submodule to the latest version:
+
+```sh
+git submodule update --remote curriculum-vitae
+```
+
 ### Configuration
 
 To use these servers, create a `.env` file in the root directory with your

--- a/_config.yml
+++ b/_config.yml
@@ -74,6 +74,7 @@ exclude:
   - Gemfile.lock
   - terraform/
   - vendor/
+  - curriculum-vitae/
   # Local files that should not be published to the site
   - hunspell/
   - scripts/

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,4 +1,4 @@
-extensions = ["md"]
+extensions = ["md", "html", "txt"]
 
 exclude_loopback = true
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,4 +1,4 @@
-extensions = ["md", "html", "txt"]
+extensions = ["md"]
 
 exclude_loopback = true
 


### PR DESCRIPTION
Add private repository `curriculum-vitae` as a GIT submodule to use its content while editing the website.

Resolves: #35