### PR TITLE
Add UptimeRobot

### DIFF
--- a/hunspell/custom.dic
+++ b/hunspell/custom.dic
@@ -1,4 +1,4 @@
-108
+109
 ADR/S
 API/S
 Backend/S
@@ -41,6 +41,7 @@ PSD/S
 PSD2
 Penta
 Qonto
+UptimeRobot/S
 README/S
 Taccari's
 Tot

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -7,6 +7,7 @@ IaC controls these infrastructural elements:
 
 - GitHub repository
 - Porkbun DNSes
+- UptimeRobot
 
 OpenTofu state is persisted on a GCS bucket.
 
@@ -19,9 +20,12 @@ To use IaC, you follow these steps.
 - Install the GitHub CLI, which the GitHub Terraform provider uses.
 - Set the variables `PORKBUN_API_KEY` and `PORKBUN_SECRET_KEY` in your
   environment that the Porkbun Terraform provider uses.
-  You can configure these variables in a `.env` file within this
-  directory and use direnv to load them.
-  (See [Tips & Tricks](../README.md#tips--tricks) in the main README file.)
+- Set the variables `UPTIMEROBOT_API_KEY` in your environment that the
+  UptimeRobot Terraform provider uses.
+
+> NOTE: You can configure these variables in a `.env` file within this directory
+> and use direnv to load them.
+> (See [Tips & Tricks](../README.md#tips--tricks) in the main README file.)
 
 For more information, see the providers’ documentation.
 See the [References](#references) section below.
@@ -38,3 +42,4 @@ commands `plan` and `apply`  to plan the changes and apply them, respectively.
 
 - [GitHub Terraform provider](https://registry.terraform.io/providers/integrations/github/latest)
 - [Porkbun Terraform provider](https://registry.terraform.io/providers/jianyuan/porkbun/latest)
+- [UptimeRobot Terraform Provider](https://registry.terraform.io/providers/uptimerobot/uptimerobot/latest)

--- a/terraform/live/uptimerobot/.terraform.lock.hcl
+++ b/terraform/live/uptimerobot/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/uptimerobot/uptimerobot" {
+  version     = "1.3.9"
+  constraints = "~> 1.3.0"
+  hashes = [
+    "h1:o031cHi6GLIz3Y4EkxRPl8YZB6aICiaBA4mSFAnatGA=",
+    "zh:291117f52005e6a76eb349bf168213ec2581150f5c4f25675c087790ee6340d9",
+    "zh:662d943299d59c21197a1e4449d64fb78ecb6cb71b0fe91db2aaf058d14a0e45",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:a22d9b3cf72f51c1d0a9d11717d5fd21fb82aff9f7a7dc471922f9a2b824d6d6",
+    "zh:bdea98f88fa3a1aa451f9847bd75293f30bae4b1b4271a9d01c7d8cb67c69158",
+    "zh:ca89a2193a6c10d2e2a3565c61fa1170af63f8533cac5501234a5e496b0e6bf9",
+    "zh:e1e1eab65e1c0e5bbe45f7278f3274055fb172bc658ef9b93cd1750a0d0be6c1",
+    "zh:f8505b6cfbfccb1872c7979d2d2c1f8ead9b5681cc74380e1f926bafeeb481e2",
+    "zh:fe274768ef6635976737b5ad6ef502932d99bfa6a36404c167a5446871855e44",
+  ]
+}

--- a/terraform/live/uptimerobot/main.tf
+++ b/terraform/live/uptimerobot/main.tf
@@ -13,3 +13,13 @@ resource "uptimerobot_monitor" "website" {
   url      = "https://gilbertotaccari.com"
   interval = 300
 }
+
+resource "uptimerobot_psp" "webisite" {
+  name = "gilbertotaccari.com Status"
+  monitor_ids = [
+    uptimerobot_monitor.website.id,
+  ]
+
+  # Prevent search engine indexing
+  no_index = true
+}

--- a/terraform/live/uptimerobot/main.tf
+++ b/terraform/live/uptimerobot/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  backend "gcs" {
+    bucket = "gilbertotaccaricom-tfstate"
+    prefix = "live/uptimerobot"
+  }
+}
+
+provider "uptimerobot" {}
+
+resource "uptimerobot_monitor" "website" {
+  name     = "gilbertotaccari.com"
+  type     = "HTTP"
+  url      = "https://gilbertotaccari.com"
+  interval = 300
+}

--- a/terraform/live/uptimerobot/versions.tf
+++ b/terraform/live/uptimerobot/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    uptimerobot = {
+      source  = "uptimerobot/uptimerobot"
+      version = "~> 1.3.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds [UptimeRobot](https://uptimerobot.com/) configuration to measure the website uptime. The service returns the current uptime status and includes a status page with historical data.

The status page is available at `https://stats.uptimerobot.com/<url_key>`, where `url_key` is the value of the resource property with the same name. You can get it from the output of this command:

```sh
tofu state show "uptimerobot_psp.webisite"
```