### PR TITLE
Update list of GitHub webhook events

### DIFF
--- a/terraform/live/github/main.tf
+++ b/terraform/live/github/main.tf
@@ -70,11 +70,14 @@ resource "github_repository_webhook" "gilbertotcc_github_io" {
 
   active = true
 
+  # Supported events by Discord:
+  # https://docs.discord.com/developers/resources/webhook#execute-github-compatible-webhook
   events = [
-    "dependabot_alert",
     "issues",
+    "issue_comment",
     "pull_request",
-    "push"
+    "pull_request_review",
+    "pull_request_review_comment"
   ]
 }
 


### PR DESCRIPTION
Update the list of the events GitHub sends to Discord via webhooks. This change removes an event not handled by Discord and `push` events that generate noise in the Discord channel.