### PR TITLE
Overwrite default email address

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -21,7 +21,7 @@
 title: Gilberto Taccari
 author:
   name: Gilberto Taccari
-#  email: your-email@example.com
+  email: ""
 description: >- # this means to ignore newlines until "baseurl:"
   Building engineering teams and fintech platforms for regulated, high-growth
   startups and scaleups.


### PR DESCRIPTION
Set author email to empty string to avoid Jekyll to use the Minima theme default one.