### PR TITLE
Silence warnings during Jekyll built

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -66,3 +66,10 @@ plugins:
 exclude:
   - .sass-cache/
   - .jekyll-cache/
+
+sass:
+  quiet_deps: true
+  silence_deprecations:
+    - import
+    - global-builtin
+    - color-functions


### PR DESCRIPTION
This commit silences the warning shown while building the website. These warnings are related to SCSS compatibility issues.