### PR TITLE
feat: define site configuration as TypeScript

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -148,8 +148,15 @@ specific files. Always refer to these before proceeding with related tasks:
   prevent execution until explicit consent is granted, ensuring GDPR compliance
   regarding international data transfers.
 
-### Configuration (`site/_config.yml`)
+### Configuration
 
+**Astro (`astro-site/src/config.ts`)**
+Site-wide values are now typed TypeScript constants, ensuring type safety and IDE autocompletion, not YAML.
+- **Metadata:** Title, author, description, lang, and URL are set here.
+- **Analytics:** Google Analytics 4 and Cookiebot IDs are configured here.
+- **Social Links:** LinkedIn and GitHub links are configured in the `social` object.
+
+**Jekyll (`site/_config.yml`)**
 - **Metadata:** Title, author, description, and URL are set here.
 - **Navigation:** Main header links are explicitly defined in
   `header_pages` to exclude administrative pages like the Privacy Policy.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -151,12 +151,15 @@ specific files. Always refer to these before proceeding with related tasks:
 ### Configuration
 
 **Astro (`astro-site/src/config.ts`)**
-Site-wide values are now typed TypeScript constants, ensuring type safety and IDE autocompletion, not YAML.
+Site-wide values are now typed TypeScript constants, ensuring type safety and
+IDE autocompletion, not YAML.
+
 - **Metadata:** Title, author, description, lang, and URL are set here.
 - **Analytics:** Google Analytics 4 and Cookiebot IDs are configured here.
 - **Social Links:** LinkedIn and GitHub links are configured in the `social` object.
 
 **Jekyll (`site/_config.yml`)**
+
 - **Metadata:** Title, author, description, and URL are set here.
 - **Navigation:** Main header links are explicitly defined in
   `header_pages` to exclude administrative pages like the Privacy Policy.

--- a/astro-site/src/config.ts
+++ b/astro-site/src/config.ts
@@ -1,0 +1,13 @@
+export const SITE = {
+  title: 'Gilberto Taccari',
+  description: 'Building engineering teams and fintech platforms for regulated, high-growth startups and scaleups.',
+  url: 'https://gilbertotaccari.com',
+  lang: 'en',
+  author: { name: 'Gilberto Taccari' },
+  googleAnalyticsId: 'G-XHFF332CDW',         // from _config.yml
+  cookiebotId: '01108c58-7b63-4ce1-ae70-3d7bdd95c7f3', // from _includes/cookiebot.html
+  social: {
+    linkedin: 'https://www.linkedin.com/in/gilbertotaccari/',
+    github: 'https://github.com/gilbertotcc',
+  },
+} as const;

--- a/astro-site/src/config.ts
+++ b/astro-site/src/config.ts
@@ -4,10 +4,10 @@ export const SITE = {
   url: 'https://gilbertotaccari.com',
   lang: 'en',
   author: { name: 'Gilberto Taccari' },
-  googleAnalyticsId: 'G-XHFF332CDW',         // from _config.yml
-  cookiebotId: '01108c58-7b63-4ce1-ae70-3d7bdd95c7f3', // from _includes/cookiebot.html
+  googleAnalyticsId: 'G-XHFF332CDW',
+  cookiebotId: '01108c58-7b63-4ce1-ae70-3d7bdd95c7f3',
   social: {
     linkedin: 'https://www.linkedin.com/in/gilbertotaccari/',
     github: 'https://github.com/gilbertotcc',
   },
-} as const;
+};

--- a/hunspell/custom.dic
+++ b/hunspell/custom.dic
@@ -1,4 +1,4 @@
-129
+132
 ADR/S
 API/S
 Astro/S
@@ -46,6 +46,7 @@ Qonto
 UptimeRobot/S
 README/S
 Taccari's
+TypeScript
 Tot
 Venezia
 Vue/S
@@ -89,6 +90,7 @@ init
 io
 jekyll/S
 json
+lang
 livereload
 llms
 localhost
@@ -111,6 +113,7 @@ sudo
 taccari/P
 tf
 toml
+ts
 tot
 txt
 url/S


### PR DESCRIPTION
Adds `astro-site/src/config.ts` with site settings mapping to current Jekyll config. Updates `GEMINI.md` configuration section.

Resolves: #67