### PR TITLE
feat: migrate data files to Astro Content Collections

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -110,8 +110,8 @@ specific files. Always refer to these before proceeding with related tasks:
 - **Formatting:** Adhere to `.markdownlint-cli2.yaml` rules.
 - **Links:** Verify all links using `lychee` (configured in `lychee.toml`).
 - **Thought Leadership Data:** The data for the "Thought Leadership" page is stored
-  in `site/_data/publications.yml`, `site/_data/speaking.yml`, and
-  `site/_data/reviews.yml`. These files are populated from the
+  in `site/_data/publications.yml`, `site/_data/reviews.yml`, and
+  `site/_data/speaking.yml`. These files are populated from the
   `curriculum-vitae` submodule. To update them:
   1. Sync the submodule: `git submodule update --remote curriculum-vitae`.
   2. Read `curriculum-vitae/publications.bib` and
@@ -119,6 +119,13 @@ specific files. Always refer to these before proceeding with related tasks:
   3. Extract the academic publications, speaking appearances, and manuscript
      reviews.
   4. Update the corresponding YAML files in `site/_data/`.
+
+  **Astro (New)**
+  Astro uses Content Collections to manage this data. The collections are
+  defined in `astro-site/src/content.config.ts` using Zod schemas for
+  type-safe validation. The collections (`publications`, `reviews`,
+  `speaking`) point directly to the legacy YAML files in `site/_data/` as
+  their source of truth, ensuring data consistency during the transition.
 - **LLM Context:** `llms.txt` provides a machine-readable summary of the site
   for LLMs, including site metadata, page links, and social information. It is
   dynamically generated using Jekyll.

--- a/astro-site/src/content.config.ts
+++ b/astro-site/src/content.config.ts
@@ -1,0 +1,43 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const speaking = defineCollection({
+  loader: glob({ pattern: 'speaking.yml', base: '../site/_data' }),
+  schema: z.array(z.object({
+    date: z.string(),
+    event: z.string(),
+    role: z.string(),
+    topic: z.string(),
+  })),
+});
+
+const reviews = defineCollection({
+  loader: glob({ pattern: 'reviews.yml', base: '../site/_data' }),
+  schema: z.array(z.object({
+    year: z.number(),
+    title: z.string(),
+    link: z.string(),
+    author: z.string(),
+    published: z.string(),
+  })),
+});
+
+const publications = defineCollection({
+  loader: glob({ pattern: 'publications.yml', base: '../site/_data' }),
+  schema: z.array(z.object({
+    type: z.string(),
+    id: z.string(),
+    title: z.string(),
+    author: z.string(),
+    year: z.union([z.string(), z.number()]),
+    editor: z.string().optional(),
+    booktitle: z.string().optional(),
+    pages: z.string().optional(),
+    publisher: z.string().optional(),
+    school: z.string().optional(),
+    journal: z.string().optional(),
+    organization: z.string().optional(),
+  })),
+});
+
+export const collections = { speaking, reviews, publications };

--- a/hunspell/custom.dic
+++ b/hunspell/custom.dic
@@ -1,4 +1,4 @@
-132
+133
 ADR/S
 API/S
 Astro/S
@@ -51,6 +51,7 @@ Tot
 Venezia
 Vue/S
 YAML/S
+Zod
 adr/S
 ai
 api/S


### PR DESCRIPTION
Sets up Astro Content Collections in content.config.ts, pointing the glob loader directly to the legacy site/_data directory as the single source of truth. Validates speaking, reviews, and publications schemas via Zod and updates the project documentation.

Resolves: #68