### PR TITLE
feat: create the llms.txt endpoint

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -139,6 +139,13 @@ specific files. Always refer to these before proceeding with related tasks:
 - **LLM Context:** `llms.txt` provides a machine-readable summary of the site
   for LLMs, including site metadata, page links, and social information. It is
   dynamically generated using Jekyll.
+
+  **Astro (New)**
+  `llms.txt` is implemented as an API endpoint at
+  `astro-site/src/pages/llms.txt.ts`. It adheres to the `llmstxt.org`
+  specification (H1 title, blockquote summary, H2 file lists). To update its
+  content, edit the string array in the `GET` function. Any `.ts` file in
+  `src/pages/` exporting a `GET` function becomes a static file at build time.
 - **AI Context Submodule:** A private submodule `curriculum-vitae` is used to
   provide personal data as context for LLM-assisted development.
   - **Syncing:** The submodule tracks the `main` branch. Use

--- a/astro-site/src/pages/llms.txt.ts
+++ b/astro-site/src/pages/llms.txt.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from 'astro';
+import { SITE } from '../config';
+
+export const GET: APIRoute = () => {
+  const now = new Date().toUTCString();
+  const body = [
+    `# ${SITE.title}`,
+    ``,
+    `> ${SITE.description}`,
+    ``,
+    `_Generated: ${now}_`,
+    ``,
+    `## Content`,
+    ``,
+    `- [Home](${SITE.url}/): Engineering leader and CTO portfolio.`,
+    `- [Thought Leadership](${SITE.url}/thought-leadership): Public speaking, Manning manuscript reviews, and academic research.`,
+    `- [Privacy Policy](${SITE.url}/privacy): Data processing and GDPR compliance details.`,
+    ``,
+    `## Social`,
+    ``,
+    `- [LinkedIn](${SITE.social.linkedin})`,
+    `- [GitHub](${SITE.social.github})`,
+    ``
+  ].join('\n');
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/hunspell/custom.dic
+++ b/hunspell/custom.dic
@@ -1,4 +1,4 @@
-134
+135
 ADR/S
 API/S
 Astro/S
@@ -95,6 +95,7 @@ json
 lang
 livereload
 llms
+llmstxt
 localhost
 lychee
 macOS


### PR DESCRIPTION
Implements astro-site/src/pages/llms.txt.ts to generate the llms.txt file natively using an Astro API endpoint. Adheres to the best practices recommended by llmstxt.org by using blockquote summaries and Markdown H2 headers. Updates GEMINI.md documentation and adds the required exception to the hunspell dictionary.

Resolves: #71