### PR TITLE
Configure sitemap

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -44,6 +44,7 @@ const pathname = Astro.url.pathname;
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />
+    <link rel="sitemap" href="/sitemap-index.xml" />
 
     <!-- Open Graph -->
     <meta property="og:title" content={title} />

--- a/site/src/pages/robors.txt.ts
+++ b/site/src/pages/robors.txt.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from 'astro';
+
+const getRobotsTxt = (sitemapURL: URL) => `\
+User-agent: *
+Allow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+
+export const GET: APIRoute = ({ site }) => {
+  const sitemapURL = new URL('sitemap-index.xml', site);
+  return new Response(getRobotsTxt(sitemapURL));
+};


### PR DESCRIPTION
Configure Astro integration `sitemap` and add `robots.txt` to the website.

The changes in this commit are taken from Astro official documentation at <https://docs.astro.build/en/guides/integrations-guide/sitemap/>.